### PR TITLE
Restrict BMO access to only required RBAC verbs

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -9,14 +9,24 @@ rules:
   resources:
   - configmaps
   verbs:
-  - "*"
+  - list
+  - get
+  - create
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - watch
+  - list
+  - update
 - apiGroups:
   - ""
   resources:
   - events
-  - secrets
   verbs:
-  - "*"
+  - create
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
This PR applies the principle of least privilege on the BMO by limiting verbs it can invoke. 
Closes #356